### PR TITLE
Code generation updates

### DIFF
--- a/core/mixins/_generate-at-breakpoints.scss
+++ b/core/mixins/_generate-at-breakpoints.scss
@@ -42,19 +42,13 @@
 
   @each $breakpoint-name in $breakpoint-names {
 
-    // Check if it's a valid breakpoint
-    @if type-of(index($all-breakpoint-names, $breakpoint-name)) == "number" {
-
-      // Palm is a special case where it uses a `max-width` media query
-      @include respond-to($breakpoint-name, $limit: if($breakpoint-name ==
-        'palm', 'max', 'min')) {
-        // Output a class which applies the style at a given breakpoint
-        .#{$class}-at-#{$breakpoint-name} {
-          @content;
-        }
+    // Palm is a special case where it uses a `max-width` media query
+    @include respond-to($breakpoint-name, $limit: if($breakpoint-name ==
+      'palm', 'max', 'min')) {
+      // Output a class which applies the style at a given breakpoint
+      .#{$class}-at-#{$breakpoint-name} {
+        @content;
       }
-    } @else {
-      @warn "Breakpoint name '#{$breakpoint-name}' not recognised.";
     }
   }
 }

--- a/core/mixins/_generate-percentage-classes-at-breakpoints.scss
+++ b/core/mixins/_generate-percentage-classes-at-breakpoints.scss
@@ -35,15 +35,21 @@ $denominators:                  (whole half third quarter fifth sixth seventh
  * The mixin.
  */
 
-@mixin generate-percentage-classes-at-breakpoints($breakpoints, $scally-type: "u", $class-name: null, $css-property: "width") {
+@mixin generate-percentage-classes-at-breakpoints($breakpoint-names, $scally-type: "u", $class-name: null, $css-property: "width") {
 
   @if $class-name {
     $class-name: "#{$class-name}-"
   }
 
+  $all-breakpoint-names: map-keys($breakpoints);
+
+  @if $breakpoint-names == all {
+    $breakpoint-names: $all-breakpoint-names;
+  }
+
   @include generate-percentage-classes("", $scally-type, $class-name, $css-property);
 
-  @each $breakpoint in $breakpoints {
+  @each $breakpoint in $breakpoint-names {
 
     @include respond-to($breakpoint) {
       @if $breakpoint {

--- a/core/mixins/_generate-percentage-classes-at-breakpoints.scss
+++ b/core/mixins/_generate-percentage-classes-at-breakpoints.scss
@@ -51,7 +51,8 @@ $denominators:                  (whole half third quarter fifth sixth seventh
 
   @each $breakpoint in $breakpoint-names {
 
-    @include respond-to($breakpoint) {
+    @include respond-to($breakpoint, $limit: if($breakpoint ==
+        'palm', 'max', 'min')) {
       @if $breakpoint {
         $breakpoint: "#{$breakpoint}-"
       }


### PR DESCRIPTION
- I realised the `respond-to` media query already handles incorrect breakpoint names so i removed the check from the `generate-at-breakpoints` mixin.
- Updated the `generate-percentage-classes-at-breakpoints` mixin to handle the palm mq correctly
- `generate-percentage-classes-at-breakpoints` handles "all" as a breakpoint option
