### PR TITLE
generate at breakpoints handles complex selectors

### DIFF
--- a/core.scss
+++ b/core.scss
@@ -37,6 +37,8 @@
 
 @import "core/functions/math-helpers";
 
+@import "core/functions/string-replace";
+
 
 /**
  * Mixins.

--- a/core/functions/_string-replace.scss
+++ b/core/functions/_string-replace.scss
@@ -6,6 +6,9 @@
 /**
  * A string helper which replaces a set of characters in a string.
  *
+ * @credit
+ * https://github.com/hail2u/scss-functions/blob/master/string/_str-replace.scss
+ *
  * @example
    str-replace("my-long-string", "long", "longer");
  */

--- a/core/functions/_string-replace.scss
+++ b/core/functions/_string-replace.scss
@@ -1,0 +1,38 @@
+/* ============================================================================
+   @CORE -> FUNCTIONS -> STRING REPLACE
+   ========================================================================= */
+
+
+/**
+ * A string helper which replaces a set of characters in a string.
+ *
+ * @example
+   str-replace("my-long-string", "long", "longer");
+ */
+
+@function str-replace($string, $substr, $newsubstr, $all: 0) {
+  $position-found: str-index($string, $substr);
+  $processed: ();
+
+  @while ($position-found and $position-found > 0) {
+    $length-substr: str-length($substr);
+    $processed: append($processed, str-slice($string, 0, $position-found - 1));
+    $processed: append($processed, $newsubstr);
+    $string: str-slice($string, $position-found + $length-substr);
+
+    $position-found: 0;
+
+    @if ($all > 0) {
+      $position-found: str-index($string, $substr);
+    }
+  }
+
+  $processed: append($processed, $string);
+  $string: "";
+
+  @each $s in $processed {
+    $string: #{$string}#{$s};
+  }
+
+  @return $string;
+}

--- a/core/mixins/_generate-at-breakpoints.scss
+++ b/core/mixins/_generate-at-breakpoints.scss
@@ -14,25 +14,15 @@
      @include font-size($font-size-small);
    }
 
-   @include generate-at-breakpoints(u-align-v-inline-top, palm lap, false) {
+   @include generate-at-breakpoints('.u-align-v-inline-top[bp] li', palm lap, false) {
      vertical-align: top;
    }
  */
 
 
-@mixin generate-at-breakpoints($class, $breakpoint-names: (), $placeholder: true) {
+$mixin-breakpoint-name-placeholder: "[bp]";
 
-  // Output sass placeholder and normal class
-  @if $placeholder {
-    %#{$class},
-    .#{$class} {
-      @content;
-    }
-  } @else {
-    .#{$class} {
-      @content;
-    }
-  }
+@mixin generate-at-breakpoints($class, $breakpoint-names: ()) {
 
   $all-breakpoint-names: map-keys($breakpoints);
 
@@ -43,10 +33,18 @@
   @each $breakpoint-name in $breakpoint-names {
 
     // Palm is a special case where it uses a `max-width` media query
-    @include respond-to($breakpoint-name, $limit: if($breakpoint-name ==
-      'palm', 'max', 'min')) {
+    $limit: if($breakpoint-name == 'palm', 'max', 'min');
+
+    @include respond-to($breakpoint-name, $limit) {
+      $final-selector: "#{$class}-at-#{$breakpoint-name}";
+
+      // Handle complex selectors by replacing a placeholder with the breakpoint suffix
+      @if str_index($class, $mixin-breakpoint-name-placeholder) != null {
+        $final-selector: str-replace($class, $mixin-breakpoint-name-placeholder, "-at-#{$breakpoint-name}");
+      }
+
       // Output a class which applies the style at a given breakpoint
-      .#{$class}-at-#{$breakpoint-name} {
+      #{$final-selector} {
         @content;
       }
     }

--- a/core/mixins/_generate-at-breakpoints.scss
+++ b/core/mixins/_generate-at-breakpoints.scss
@@ -10,7 +10,7 @@
  * http://codepen.io/team/westfieldlabs/full/Bcfyz
  *
  * @example
-   @include generate-at-breakpoints(u-text-size-small, all) {
+   @include generate-at-breakpoints('.u-text-size-small', all) {
      @include font-size($font-size-small);
    }
 

--- a/core/mixins/_generate-at-breakpoints.scss
+++ b/core/mixins/_generate-at-breakpoints.scss
@@ -14,7 +14,7 @@
      @include font-size($font-size-small);
    }
 
-   @include generate-at-breakpoints('.u-align-v-inline-top[bp] li', palm lap, false) {
+   @include generate-at-breakpoints('.u-demo[bp] li', palm lap, false) {
      vertical-align: top;
    }
  */
@@ -24,7 +24,7 @@
  * Settings.
  */
 
-// This placeholder will be replaced with the breakpoint name when passed in as an argument
+// This placeholder will be replaced with the breakpoint name
 $mixin-breakpoint-name-placeholder: "{bp}";
 
 @mixin generate-at-breakpoints($class, $breakpoint-names: ()) {
@@ -43,9 +43,11 @@ $mixin-breakpoint-name-placeholder: "{bp}";
     @include respond-to($breakpoint-name, $limit) {
       $final-selector: "#{$class}-at-#{$breakpoint-name}";
 
-      // Handle complex selectors by replacing a placeholder with the breakpoint suffix
+      // Handle complex selectors by replacing a placeholder with the breakpoint
+      // suffix
       @if str_index($class, $mixin-breakpoint-name-placeholder) != null {
-        $final-selector: str-replace($class, $mixin-breakpoint-name-placeholder, "-at-#{$breakpoint-name}");
+        $final-selector: str-replace($class, $mixin-breakpoint-name-placeholder,
+         "-at-#{$breakpoint-name}");
       }
 
       // Output a class which applies the style at a given breakpoint

--- a/core/mixins/_generate-at-breakpoints.scss
+++ b/core/mixins/_generate-at-breakpoints.scss
@@ -20,7 +20,7 @@
  */
 
 
-$mixin-breakpoint-name-placeholder: "[bp]";
+$mixin-breakpoint-name-placeholder: "{bp}";
 
 @mixin generate-at-breakpoints($class, $breakpoint-names: ()) {
 

--- a/core/mixins/_generate-at-breakpoints.scss
+++ b/core/mixins/_generate-at-breakpoints.scss
@@ -20,6 +20,11 @@
  */
 
 
+/**
+ * Settings.
+ */
+
+// This placeholder will be replaced with the breakpoint name when passed in as an argument
 $mixin-breakpoint-name-placeholder: "{bp}";
 
 @mixin generate-at-breakpoints($class, $breakpoint-names: ()) {

--- a/utilities/_u-list-inline.scss
+++ b/utilities/_u-list-inline.scss
@@ -189,7 +189,8 @@ $list-inline-divider-thickness:    1 !default;
 %u-list-inline--delimited-slash > li + li:before,
 .u-list-inline--delimited-slash > li + li:before {content: "/";}
 
-@include generate-at-breakpoints(".u-list-inline--delimited-slash{bp} > li + li:before", palm lap desk) {
+@include generate-at-breakpoints(".u-list-inline--delimited-slash{bp} > li +
+ li:before", palm lap desk) {
   content: "/";
 }
 
@@ -199,7 +200,9 @@ $list-inline-divider-thickness:    1 !default;
   %u-list-inline--delimited-slash[class*="u-list-inline--spacing"] > li + li:before,
   .u-list-inline--delimited-slash[class*="u-list-inline--spacing"] > li + li:before {display: inline-block;}
 
-  @include generate-at-breakpoints('.u-list-inline--delimited-slash{bp}[class*="u-list-inline--spacing"] > li + li:before', palm lap desk) {
+  @include generate-at-breakpoints(
+    '.u-list-inline--delimited-slash{bp}[class*="u-list-inline--spacing"] > li
+     + li:before', palm lap desk) {
     display: inline-block;
   }
 

--- a/utilities/_u-list-inline.scss
+++ b/utilities/_u-list-inline.scss
@@ -189,7 +189,7 @@ $list-inline-divider-thickness:    1 !default;
 %u-list-inline--delimited-slash > li + li:before,
 .u-list-inline--delimited-slash > li + li:before {content: "/";}
 
-@include generate-at-breakpoints(".u-list-inline--delimited-slash[bp] > li + li:before", palm lap desk) {
+@include generate-at-breakpoints(".u-list-inline--delimited-slash{bp} > li + li:before", palm lap desk) {
   content: "/";
 }
 
@@ -199,7 +199,7 @@ $list-inline-divider-thickness:    1 !default;
   %u-list-inline--delimited-slash[class*="u-list-inline--spacing"] > li + li:before,
   .u-list-inline--delimited-slash[class*="u-list-inline--spacing"] > li + li:before {display: inline-block;}
 
-  @include generate-at-breakpoints('.u-list-inline--delimited-slash[bp][class*="u-list-inline--spacing"] > li + li:before', palm lap desk) {
+  @include generate-at-breakpoints('.u-list-inline--delimited-slash{bp}[class*="u-list-inline--spacing"] > li + li:before', palm lap desk) {
     display: inline-block;
   }
 

--- a/utilities/_u-list-inline.scss
+++ b/utilities/_u-list-inline.scss
@@ -189,11 +189,19 @@ $list-inline-divider-thickness:    1 !default;
 %u-list-inline--delimited-slash > li + li:before,
 .u-list-inline--delimited-slash > li + li:before {content: "/";}
 
+@include generate-at-breakpoints(".u-list-inline--delimited-slash[bp] > li + li:before", palm lap desk) {
+  content: "/";
+}
+
   // When used in conjuction with the Spacing -> Base modifier
 
   // Make the pseudo element `inline-block` as it needs `margin-right`
   %u-list-inline--delimited-slash[class*="u-list-inline--spacing"] > li + li:before,
   .u-list-inline--delimited-slash[class*="u-list-inline--spacing"] > li + li:before {display: inline-block;}
+
+  @include generate-at-breakpoints('.u-list-inline--delimited-slash[bp][class*="u-list-inline--spacing"] > li + li:before', palm lap desk) {
+    display: inline-block;
+  }
 
   // Base
   %u-list-inline--spacing-base.u-list-inline--delimited-slash > li + li:before,


### PR DESCRIPTION
When passing in a complex selector with a `>` you need to put it in quotes as sass will try to evaluate it as a mathematical equation
