### PR TITLE
Fix heading mixin

### DIFF
--- a/core/mixins/_target-headings.scss
+++ b/core/mixins/_target-headings.scss
@@ -29,14 +29,14 @@
       $selector: "h#{$i}";
 
       @if $double-stranded {
-        $selector: "#{$selector},.#{$selector}";
+        $selector: "#{$selector}, .#{$selector}";
       }
 
       $selector-list: append($selector-list, $selector);
     }
 
     // Combine and output all selectors with css content
-    $full-selector: join($selector-list, ", ");
+    $full-selector: join($selector-list, (), "comma");
     #{$full-selector} {
       @content
     }


### PR DESCRIPTION
List was not being joined correctly. Output is now 

```
h1, .h1, h2, .h2, h3, .h3, hr, p {
  margin-bottom: 1.5rem; 
}
```
