### PR TITLE
Fix respond-range mixin when lap breakpoint is used

### DIFF
--- a/core/mixins/_media-queries.scss
+++ b/core/mixins/_media-queries.scss
@@ -65,6 +65,10 @@
 
       $next-breakpoint-index: $breakpoint-index + 1;
 
+      @if $min-value == "lap" {
+        $next-breakpoint-index: $breakpoint-index + 2;
+      }
+
       @if $next-breakpoint-index <= length($breakpoint-values) {
         $max-value: nth($breakpoint-values, $next-breakpoint-index);
       }


### PR DESCRIPTION
Closes #125 

This: 

```
@include respond-range(lap) {
     .foo {background: red;}
}
```

now generates

```
@media (min-width: 40.0625em) and (max-width: 75em) {
  .foo {
    background: red; } }
```

instead of

```
@media (min-width: 40.0625em) and (max-width: 56.3125em) {
  .foo {
    background: red; } }
```
